### PR TITLE
Updated parent constructor call

### DIFF
--- a/cki_sitelist/ft.cki_sitelist.php
+++ b/cki_sitelist/ft.cki_sitelist.php
@@ -17,7 +17,7 @@
 
 		public function Cki_sitelist_ft()
 		{
-			parent::EE_Fieldtype();
+			parent::__construct();
 		}
 
 		public function display_field($data, $cell = FALSE)


### PR DESCRIPTION
Updated the call to parent::EE_Fieldtype() in the constructor to parent::__construct() since ExpressionEngine removed the matching name constructor.
